### PR TITLE
Use valid version in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Format your message using [Zulip Markdown](https://zulip.com/help/format-your-me
 **Send a stream message**
 ```yml
 - name: Send a stream message
-  uses: zulip/github-actions-zulip@v0.2.0
+  uses: zulip/github-actions-zulip@v0.1.2
   with:
     api-key: 'abcd1234'
     email: 'username@example.com'
@@ -57,7 +57,7 @@ Format your message using [Zulip Markdown](https://zulip.com/help/format-your-me
 **Send a private message**
 ```yml
 - name: Send a private message
-  uses: zulip/github-actions-zulip@v0.2.0
+  uses: zulip/github-actions-zulip@v0.1.2
   with:
     api-key: 'abcd1234'
     email: 'username@example.com'


### PR DESCRIPTION
The version that was previously in the examples won't work as it doesn't exist.