### PR TITLE
deps: Upgrade from NodeJS v16 to v20

### DIFF
--- a/send-message/action.yml
+++ b/send-message/action.yml
@@ -27,5 +27,5 @@ inputs:
     description: 'The content of the message. Maximum message size of 10000 bytes.'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: '../dist/send-message/index.js'


### PR DESCRIPTION
GitHub Actions has deprecated NodeJS 16 actions.

See more at https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/