### PR TITLE
deps: Upgrade from NodeJS v20 to v24

### DIFF
--- a/send-message/action.yml
+++ b/send-message/action.yml
@@ -27,5 +27,5 @@ inputs:
     description: 'The content of the message. Maximum message size of 10000 bytes.'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: '../dist/send-message/index.js'


### PR DESCRIPTION
GitHub Actions has deprecated NodeJS 20 actions.

See more at https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Closes: https://github.com/zulip/github-actions-zulip/issues/135